### PR TITLE
feat: extract and export determineLabelChanges function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,71 @@ Otherwise, a new label is created.
 npm i set-github-repository-labels
 ```
 
+`set-github-repository-labels` provides two functions:
+
+- [`determineLabelChanges`](#determinelabelchanges): describes the changes a repository's labels would need to get to the outcome labels
+- [`setGitHubRepositoryLabels`](#setgithubrepositorylabels): sends the API requests to the repository to set its labels
+
+## `determineLabelChanges`
+
+Takes two required parameters:
+
+1. `existingLabels`: an array of the labels that currently exist on a repository
+2. `outcomeLabels`: an array of the labels that you want to exist on the repository
+
+Returns an array of change objects describing the network requests that would be needed to change the repository's existing labels to the outcome labels.
+
+For example, determine label changes on an existing repository with only one label to having two:
+
+```ts
+import { determineLabelChanges } from "set-github-repository-labels";
+
+const changes = determineLabelChanges(
+	[{ color: "ff0000", description: "Something isn't working.", name: "bug" }],
+	[
+		{
+			color: "d73a4a",
+			description: "Something isn't working 🐛",
+			name: "type: bug",
+		},
+		{
+			aliases: ["enhancement"],
+			color: "a2eeef",
+			description: "New enhancement or request 🚀",
+			name: "type: feature",
+		},
+	],
+);
+
+for (const change of changes) {
+	switch (change.type) {
+		case "delete":
+			console.log(`DELETE: ${change.name}`);
+			break;
+		case "patch":
+			console.log(`PATCH: ${change.originalName} to ${change.newName}`);
+			break;
+		case "post":
+			console.log(`POST: ${change.name}`);
+			break;
+	}
+}
+```
+
+See `src/types.ts` for the specific properties that exist on the change objects.
+
+## `setGitHubRepositoryLabels`
+
+Takes a parameters object with the following properties corresponding to [Shell options](#shell):
+
+- `auth` _(optional)_: Auth token to create a new GitHub Octokit
+- `bandwidth` _(optional)_: How many requests to send at once
+- `labels` _(required)_: Outcome labels to end with on the repository
+- `owner` _(required)_: Organization or user the repository is owned by
+- `repository` _(required)_: Name of the repository
+
+It returns a Promise for sending requests to the GitHub API to update the repository's labels.
+
 ```ts
 import { setGitHubRepositoryLabels } from "set-github-repository-labels";
 

--- a/src/determineLabelChanges.test.ts
+++ b/src/determineLabelChanges.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { determineLabelChanges } from "./determineLabelChanges.js";
 

--- a/src/determineLabelChanges.test.ts
+++ b/src/determineLabelChanges.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { determineLabelChanges } from "./determineLabelChanges.js";
+
+const mockOutcomeLabel = {
+	color: "000000",
+	description: "def ghi",
+	name: "area: abc",
+};
+
+describe("migrateRepositoryLabels", () => {
+	it("creates an outcome label when there are no existing labels", () => {
+		const actual = determineLabelChanges([], [mockOutcomeLabel]);
+
+		expect(actual).toEqual([
+			{
+				color: "000000",
+				description: "def ghi",
+				name: "area: abc",
+				type: "post",
+			},
+		]);
+	});
+
+	it("creates a new outcome label when an existing label doesn't have an equivalent", () => {
+		const actual = determineLabelChanges(
+			[
+				{
+					color: "111111",
+					description: "jkl mno",
+					name: "other",
+				},
+			],
+			[mockOutcomeLabel],
+		);
+
+		expect(actual).toEqual([
+			{
+				color: "000000",
+				description: "def ghi",
+				name: "area: abc",
+				type: "post",
+			},
+		]);
+	});
+
+	it("doesn't edit a outcome label when it already exists with the same information", () => {
+		const actual = determineLabelChanges(
+			[mockOutcomeLabel],
+			[mockOutcomeLabel],
+		);
+
+		expect(actual).toEqual([]);
+	});
+
+	it("edits the outcome label when it already exists with different color", () => {
+		const actual = determineLabelChanges(
+			[
+				{
+					...mockOutcomeLabel,
+					color: "111111",
+				},
+			],
+			[mockOutcomeLabel],
+		);
+
+		expect(actual).toEqual([
+			{
+				color: "000000",
+				description: "def ghi",
+				newName: "area: abc",
+				originalName: "area: abc",
+				type: "patch",
+			},
+		]);
+	});
+
+	it("edits the outcome label when it already exists with a different description", () => {
+		const actual = determineLabelChanges(
+			[
+				{
+					...mockOutcomeLabel,
+					description: "updated",
+				},
+			],
+			[mockOutcomeLabel],
+		);
+
+		expect(actual).toEqual([
+			{
+				color: "000000",
+				description: "def ghi",
+				newName: "area: abc",
+				originalName: "area: abc",
+				type: "patch",
+			},
+		]);
+	});
+
+	it("deletes an existing non-outcome label when the equivalent outcome label already exists", () => {
+		const actual = determineLabelChanges(
+			[
+				{
+					color: "000000",
+					description: "def ghi",
+					name: "abc",
+				},
+				{
+					color: "000000",
+					description: "def ghi",
+					name: "area: abc",
+				},
+			],
+			[mockOutcomeLabel],
+		);
+
+		expect(actual).toEqual([
+			{
+				name: "abc",
+				type: "delete",
+			},
+		]);
+	});
+
+	it("doesn't delete a pre-existing label when it isn't a outcome label", () => {
+		const actual = determineLabelChanges(
+			[
+				{
+					color: "000000",
+					description: "def ghi",
+					name: "unknown",
+				},
+			],
+			[mockOutcomeLabel],
+		);
+
+		expect(actual).toEqual([
+			{
+				color: "000000",
+				description: "def ghi",
+				name: "area: abc",
+				type: "post",
+			},
+		]);
+	});
+
+	it("deletes the existing duplicate outcome label and edits the label with the outcome name and different color when both exist", () => {
+		const actual = determineLabelChanges(
+			[
+				{
+					color: "000000",
+					description: "def ghi",
+					name: "abc",
+				},
+				{
+					color: "111111",
+					description: "def ghi",
+					name: "area: abc",
+				},
+			],
+			[mockOutcomeLabel],
+		);
+
+		expect(actual).toEqual([
+			{
+				name: "abc",
+				type: "delete",
+			},
+			{
+				color: "000000",
+				description: "def ghi",
+				newName: "area: abc",
+				originalName: "area: abc",
+				type: "patch",
+			},
+		]);
+	});
+
+	it("deletes the existing duplicate outcome label and does not edit the label with the outcome name and same information when both exist", () => {
+		const actual = determineLabelChanges(
+			[
+				{
+					color: "000000",
+					description: "def ghi",
+					name: "abc",
+				},
+				{
+					color: "000000",
+					description: "def ghi",
+					name: "area: abc",
+				},
+			],
+			[mockOutcomeLabel],
+		);
+
+		expect(actual).toEqual([
+			{
+				name: "abc",
+				type: "delete",
+			},
+		]);
+	});
+});

--- a/src/determineLabelChanges.ts
+++ b/src/determineLabelChanges.ts
@@ -1,0 +1,89 @@
+import { getExistingEquivalentLabels } from "./getExistingEquivalentLabels.js";
+import { OutcomeLabel } from "./types.js";
+
+export interface ExistingLabel {
+	color?: null | string;
+	description?: null | string;
+	name: string;
+}
+
+export type LabelChange =
+	| LabelChangeDelete
+	| LabelChangePatch
+	| LabelChangePost;
+
+export interface LabelChangeDelete {
+	name: string;
+	type: "delete";
+}
+
+export interface LabelChangePatch {
+	color: string;
+	description: string;
+	newName: string;
+	originalName: string;
+	type: "patch";
+}
+
+export interface LabelChangePost {
+	color: string;
+	description: string;
+	name: string;
+	type: "post";
+}
+
+export function determineLabelChanges(
+	existingLabels: ExistingLabel[],
+	outcomeLabels: OutcomeLabel[],
+) {
+	const changes: LabelChange[] = [];
+
+	for (const outcomeLabel of outcomeLabels) {
+		const existingEquivalents = getExistingEquivalentLabels(
+			existingLabels,
+			outcomeLabel,
+		);
+		const existingIdentical = existingLabels.find(
+			(existing) => existing.name === outcomeLabel.name,
+		);
+
+		// Case: the repo has neither of the two label types
+		if (!existingEquivalents.length) {
+			changes.push({
+				color: outcomeLabel.color.replace("#", ""),
+				description: outcomeLabel.description,
+				name: outcomeLabel.name,
+				type: "post",
+			});
+			continue;
+		}
+
+		for (const existingEquivalent of existingEquivalents) {
+			// Case: the repo already has both prefixed and non-prefixed label name types
+			// E.g. both "area: documentation" and "documentation"
+			if (existingEquivalent.name !== outcomeLabel.name && existingIdentical) {
+				changes.push({ name: existingEquivalent.name, type: "delete" });
+				continue;
+			}
+
+			// Case: the repo has one of the two label types, with >=1 different property
+			// E.g. "documentation" and the same color and description
+			// E.g. "area: documentation" but with a different color
+			if (
+				outcomeLabel.color !== existingEquivalent.color ||
+				outcomeLabel.description !== existingEquivalent.description ||
+				outcomeLabel.name !== existingEquivalent.name
+			) {
+				changes.push({
+					color: outcomeLabel.color.replace("#", ""),
+					description: outcomeLabel.description,
+					newName: outcomeLabel.name,
+					originalName: existingEquivalent.name,
+					type: "patch",
+				});
+			}
+		}
+	}
+
+	return changes;
+}

--- a/src/getExistingEquivalentLabels.test.ts
+++ b/src/getExistingEquivalentLabels.test.ts
@@ -4,7 +4,7 @@ import {
 	getExistingEquivalentLabels,
 	GitHubLabelData,
 } from "./getExistingEquivalentLabels.js";
-import { OutcomeLabel } from "./options.js";
+import { OutcomeLabel } from "./types.js";
 
 const createGitHubLabelData = (overrides: Partial<GitHubLabelData>) => ({
 	color: "#000000",

--- a/src/getExistingEquivalentLabels.ts
+++ b/src/getExistingEquivalentLabels.ts
@@ -1,8 +1,8 @@
-import { OutcomeLabel } from "./options.js";
+import { OutcomeLabel } from "./types.js";
 
 export interface GitHubLabelData {
-	color: string;
-	description: null | string;
+	color?: null | string;
+	description?: null | string;
 	name: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
+export * from "./determineLabelChanges.js";
 export * from "./options.js";
 export * from "./setGitHubRepositoryLabels.js";
+export * from "./types.js";

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,13 +1,5 @@
 import { z } from "zod";
 
-export interface GitHubRepositoryLabelsSettings {
-	auth?: string;
-	bandwidth?: number;
-	labels: OutcomeLabel[];
-	owner: string;
-	repository: string;
-}
-
 export const defaultOptions = {
 	// https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits
 	// 1800 points per minute, or 30 points per second
@@ -15,8 +7,6 @@ export const defaultOptions = {
 	// 30 points per second / 5 points per request = 6 requests per second
 	bandwidth: 6,
 };
-
-export type OutcomeLabel = z.infer<typeof zLabel>;
 
 export const zLabel = z.object({
 	aliases: z.array(z.string()).optional(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+import { zLabel } from "./options.js";
+
+export interface GitHubRepositoryLabelsSettings {
+	auth?: string;
+	bandwidth?: number;
+	labels: OutcomeLabel[];
+	owner: string;
+	repository: string;
+}
+
+export type OutcomeLabel = z.infer<typeof zLabel>;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #13
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/set-github-repository-labels/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/set-github-repository-labels/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Extracts the _"how do I change an existing set of labels to these outcome labels?"_ logic from the asynchronous `setGitHubRepositoryLabels` function into a new synchronous `determineLabelChanges` function. Documents both in the README.md as well.

`determineLabelChanges` will be able to be used by create-typescript-app to determine the list of API calls to setup / transition a repository's labels: https://github.com/JoshuaKGoldberg/create-typescript-app/issues/1977#issuecomment-2718605049

Intentionally copies unit tests because I think it's good for both `determineLabelChanges` and `setGitHubRepositoryLabels` to be tested end-to-end-ish.

💖 